### PR TITLE
fix(jsonlab):patch struct2data

### DIFF
--- a/loadjson.m
+++ b/loadjson.m
@@ -137,7 +137,7 @@ function object = parse_object(varargin)
         end
     end
     parse_char('}');
-    if(isstruct(object))
+    if(isstruct(object))    
         object=struct2jdata(object);
     end
 

--- a/savejson.m
+++ b/savejson.m
@@ -183,7 +183,7 @@ elseif(isobject(item))
     txt=matlabobject2json(name,item,level,varargin{:});
 elseif(jsonopt('CollapseEmptyArrays', 1, varargin{:}) && ...
         ((length(size(item))>2) || ((isempty(item) && any(size(item))))))
-    txt=cell2json(name, {}, level, varargin{:});
+    txt=mat2json(name, [], level, varargin{:});
 else
     txt=mat2json(name,item,level,varargin{:});
 end

--- a/savejson.m
+++ b/savejson.m
@@ -39,6 +39,12 @@ function json=savejson(rootname,obj,varargin)
 %                         _ArrayData_ array will include two columns 
 %                         (4 for sparse) to record the real and imaginary 
 %                         parts, and also "_ArrayIsComplex_":1 is added. 
+%        opt.CollapseEmptyArrays [1|0]: When set to 0, empty arrays with
+%                         dimension greater than 2 or non-zero size along
+%                         any dimension get converted to a struct (see
+%                         ArrayToStruct). Otherwise, these will all get
+%                         treated the same way as empty arrays with size
+%                         [0,0].
 %        opt.ParseLogical [0|1]: if this is set to 1, logical array elem
 %                         will use true/false rather than 1/0.
 %        opt.SingletArray [0|1]: if this is set to 1, arrays with a single
@@ -175,6 +181,9 @@ elseif ischar(item)
     txt=str2json(name,item,level,varargin{:});
 elseif(isobject(item)) 
     txt=matlabobject2json(name,item,level,varargin{:});
+elseif(jsonopt('CollapseEmptyArrays', 1, varargin{:}) && ...
+        ((length(size(item))>2) || ((isempty(item) && any(size(item))))))
+    txt=cell2json(name, {}, level, varargin{:});
 else
     txt=mat2json(name,item,level,varargin{:});
 end

--- a/struct2jdata.m
+++ b/struct2jdata.m
@@ -86,7 +86,12 @@ if(~isempty(strmatch('x0x5F_ArrayType_',fn)) && ~isempty(strmatch('x0x5F_ArrayDa
         if(iscpx && size(ndata,2)==2)
              ndata=complex(ndata(:,1),ndata(:,2));
         end
-        ndata=reshape(ndata(:),data(j).x0x5F_ArraySize_);
+        if iscell(data(j).x0x5F_ArraySize_)
+            arraySize = [data(j).x0x5F_ArraySize_{:}];
+        else
+            arraySize = data(j).x0x5F_ArraySize_;
+        end
+        ndata=reshape(ndata(:),arraySize);
     end
     newdata{j}=ndata;
   end


### PR DESCRIPTION
This modifies `savejson` so that if a new optional flag called `CollapseEmptyArrays` is set to `1` then when one of these problematic empty arrays, e.g. `zeros([1,1,1,10])` is encountered, it instead replaces the item with `[]` which gets written to `null` in the JSON. This is consistent because `null` gets loaded back to an empty array `[]` in MATLAB.

Additionally, `struct2jdata` is modified so that if you do not use this flag, the round trip between empty arrays and JSON still works properly by unpacking the array size cell into a normal array for reshaping